### PR TITLE
Add an acceptable optional type

### DIFF
--- a/snippets/files.tyr
+++ b/snippets/files.tyr
@@ -1,8 +1,9 @@
 function main() {
-    var f: file = file_open("snippets/files.tyr", "r");
+    var f: file = file_open("snippets/files.tyr", "r")!;
 
+    var eof: i8 = -1;
     var c = f.read_char();
-    while c != -1 {
+    while c != eof {
         print(c);
         c = f.read_char();
     }

--- a/snippets/optionals/elvis.tyr
+++ b/snippets/optionals/elvis.tyr
@@ -1,0 +1,9 @@
+function main() {
+    var x1: ?i32 = nil;
+    var result1 = x1 ?: 42;
+    println(result1);
+
+    var x2: ?i32 = 10;
+    var result2 = x2 ?: 27;
+    println(result2);
+}

--- a/snippets/optionals/optionals.tyr
+++ b/snippets/optionals/optionals.tyr
@@ -1,0 +1,20 @@
+record Point {
+    x: f32,
+    y: f32
+}
+
+record Line {
+    p1: Point,
+    p2: Point
+}
+
+function main() {
+    var p: ?Point = Point {
+        3.4, 5.6
+    };
+
+    var x: ?f32 = p?.x;
+
+    println(x);
+
+}

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -339,6 +339,50 @@ pub fn format_typecheck_error(error: &TypeCheckError) -> String {
                 highlight,
             )
         }
+        TypeCheckError::CannotDeduceTypeFromContext(loc) => {
+            let error_line = get_error_line(loc);
+            let highlight = format!(
+                "    |\n{}\n    |{}",
+                format_error_line(loc, &error_line),
+                format_highlight(loc)
+            );
+            format!(
+                "{} cannot deduce type from context, at {}\n{}",
+                log_level,
+                format_location(loc),
+                highlight,
+            )
+        }
+        TypeCheckError::NonNillableType(type_kind, loc) => {
+            let error_line = get_error_line(loc);
+            let highlight = format!(
+                "    |\n{}\n    |{}",
+                format_error_line(loc, &error_line),
+                format_highlight(loc)
+            );
+            format!(
+                "{} `{}` is a non-nillable type, at {}\n{}",
+                log_level,
+                type_kind,
+                format_location(loc),
+                highlight,
+            )
+        }
+        TypeCheckError::CannotPassOptionalTypeToFunction { type_kind, loc } => {
+            let error_line = get_error_line(loc);
+            let highlight = format!(
+                "    |\n{}\n    |{}",
+                format_error_line(loc, &error_line),
+                format_highlight(loc)
+            );
+            format!(
+                "{} cannot print optional type `{}`, at {}\n{}",
+                log_level,
+                type_kind,
+                format_location(loc),
+                highlight,
+            )
+        }
     }
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -37,6 +37,7 @@ pub enum TokenKind {
     CloseAngleEquals,
     OpenSquare,
     CloseSquare,
+    Bang,
     BangEquals,
     AndKeyword,
     OrKeyword,
@@ -65,6 +66,10 @@ pub enum TokenKind {
     ColonColon,
     MatchKeyword,
     FatArrow,
+    QuestionMark,
+    NilKeyword,
+    QuestionDot,
+    QuestionColon,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -393,6 +398,26 @@ pub fn lex_file(file: String) -> Result<Vec<Token>, LexError> {
 
                     col += advance_by;
                 }
+                '?' => {
+                    let (token_kind, text, advance_by) = match line.chars().nth(col + 1) {
+                        Some(next_char) if next_char == '.' => (TokenKind::QuestionDot, "?.", 2),
+                        Some(next_char) if next_char == ':' => (TokenKind::QuestionColon, "?:", 2),
+                        _ => (TokenKind::QuestionMark, "?", 1),
+                    };
+
+                    tokens.push(Token::new(
+                        token_kind,
+                        text.to_owned(),
+                        Loc {
+                            file: file_path.to_string_lossy().into_owned(),
+                            row,
+                            col,
+                            len: advance_by,
+                        },
+                    ));
+
+                    col += advance_by;
+                }
                 '{' => {
                     tokens.push(Token::new(
                         TokenKind::OpenCurly,
@@ -463,7 +488,7 @@ pub fn lex_file(file: String) -> Result<Vec<Token>, LexError> {
                 '!' => {
                     let (token_kind, text, advance_by) = match line.chars().nth(col + 1) {
                         Some(next_char) if next_char == '=' => (TokenKind::BangEquals, "!=", 2),
-                        _ => todo!(), //(TokenKind::OpenAngleEquals, "<", 1),
+                        _ => (TokenKind::Bang, "!", 1),
                     };
 
                     tokens.push(Token::new(
@@ -572,6 +597,7 @@ fn match_keyword(identifier: &String) -> Option<TokenKind> {
         "with" => Some(TokenKind::WithKeyword),
         "enum" => Some(TokenKind::EnumKeyword),
         "match" => Some(TokenKind::MatchKeyword),
+        "nil" => Some(TokenKind::NilKeyword),
         _ => None,
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn main() {
                         loc.col + 1
                     )
                 }
-                ParseError::CannotStaticallyAccess(expression) => todo!(),
+                ParseError::CannotStaticallyAccess(..) => todo!(),
             }
             return;
         }

--- a/src/rewriter.rs
+++ b/src/rewriter.rs
@@ -298,6 +298,18 @@ fn rewrite_expression(expression: CheckedExpression) -> Result<CheckedExpression
                 loc: expression.loc,
             })
         }
+        CheckedExpressionKind::SafeAccessor { accessee, member } => {
+            let rewritten_accessee = rewrite_expression(*accessee)?;
+
+            Ok(CheckedExpression {
+                kind: CheckedExpressionKind::SafeAccessor {
+                    accessee: Box::new(rewritten_accessee),
+                    member,
+                },
+                type_kind: expression.type_kind,
+                loc: expression.loc,
+            })
+        }
         CheckedExpressionKind::StaticAccessor { name, member } => Ok(CheckedExpression {
             kind: CheckedExpressionKind::StaticAccessor { name, member },
             type_kind: expression.type_kind,
@@ -314,6 +326,27 @@ fn rewrite_expression(expression: CheckedExpression) -> Result<CheckedExpression
                 },
                 type_kind: expression.type_kind,
                 loc: expression.loc,
+            })
+        }
+        CheckedExpressionKind::Nil => Ok(expression),
+        CheckedExpressionKind::ForceUnwrap { expression } => Ok(CheckedExpression {
+            kind: CheckedExpressionKind::ForceUnwrap {
+                expression: Box::new(rewrite_expression(*expression.clone())?),
+            },
+            type_kind: expression.type_kind.clone(),
+            loc: expression.loc.clone(),
+        }),
+        CheckedExpressionKind::NilCoalesce { optional, default } => {
+            let rewritten_optional = rewrite_expression(*optional)?;
+            let rewritten_default = rewrite_expression(*default)?;
+
+            Ok(CheckedExpression {
+                kind: CheckedExpressionKind::NilCoalesce {
+                    optional: Box::new(rewritten_optional),
+                    default: Box::new(rewritten_default),
+                },
+                type_kind: expression.type_kind.clone(),
+                loc: expression.loc.clone(),
             })
         }
     };


### PR DESCRIPTION
Adds optional types, denoted by `?T`, along with several operations to make optionals convenient:

- The `!` postfix operator will force unwrap an optional, exiting the program unceremoniously for now if the optional is none
- The `?.` operator will safely access members of or call a function with an optional type
- The `?:` operator will allow you to provide a default for an optional type